### PR TITLE
GitHub action: fix ref master -> main

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -32,9 +32,9 @@ jobs:
       - run: npm run build
 
       - run: aws s3 cp build s3://${{ secrets.BUCKET_NAME }}/ --recursive
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
       - run: aws s3 cp build s3://${{ secrets.BUCKET_NAME }}/${{github.ref}} --recursive
-        if: github.ref != 'refs/heads/master'
+        if: github.ref != 'refs/heads/main'
 
       - name: comment PR
         uses: unsplash/comment-on-pr@master
@@ -43,4 +43,4 @@ jobs:
         with:
           msg: "Check out a preview at https://thelist.app/${{github.ref}}!"
           check_for_duplicate_msg: true
-        if: github.ref != 'refs/heads/master'
+        if: github.ref != 'refs/heads/main'


### PR DESCRIPTION
🤦 I forgot the name of our default branch was `main` not `master`.