### PR TITLE
Completed item filtering works but...

### DIFF
--- a/src/components/ListItems/ListItems.js
+++ b/src/components/ListItems/ListItems.js
@@ -8,7 +8,38 @@ const ListItems = ({
   entries, deleteItem, updateItem, completeItem,
 }) => (
   <ul className={styles.list}>
-    {entries.map(({ key, text, isCompleted }) => (
+    {entries.filter(({ isCompleted }) => !isCompleted).map(({ key, text, isCompleted }) => (
+      <li key={key} className={styles.listItem}>
+        <input
+          type="text"
+          id={key}
+          value={text}
+          onChange={(e) => updateItem(e.target.value, key)}
+          style={{ textDecoration: isCompleted ? 'line-through' : '' }}
+        />
+        {' '}
+        <FontAwesomeIcon
+          icon={faTrash}
+          onClick={() => deleteItem(key)}
+          role="button"
+          aria-label={`Delete item: ${text}`}
+          data-testid={`delete-item-${text}`}
+          tabIndex={0}
+          className={styles.deleteIcon}
+        />
+        <FontAwesomeIcon
+          icon={faCheckCircle}
+          onClick={() => completeItem(key)}
+          role="button"
+          aria-label={`Added item: ${text}`}
+          data-testid={`complete-item-${text}`}
+          tabIndex={0}
+          className={isCompleted ? (styles.completedIcon) : (styles.completeIcon)}
+        />
+      </li>
+    ))}
+    <h3>Added items</h3>
+    {entries.filter(({ isCompleted }) => isCompleted).map(({ key, text, isCompleted }) => (
       <li key={key} className={styles.listItem}>
         <input
           type="text"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9193732/98819295-96a8ce80-2424-11eb-97ea-f74d5485771a.png)

I have been able to filter items based on the "isCompleted" logic, but in doing so the item code is repeated. I tried using sort() but it doesn't seem to like Booleans... Also based on the designs there would be a heading in between.

Possibilities:

- Do it a completely different way that hasn't been considered.

- Move the repeated section of code to a new file, and source it in some way.

- Leave it as it is - the completed items will likely change in style or functionality in the future that it will effectively be a different component anyway.