### PR TITLE
Assetlink file for linking pwa to google play store

### DIFF
--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -4,7 +4,7 @@
         "namespace": "android_app",
         "package_name": "app.thelist.twa",
         "sha256_cert_fingerprints": [
-        "7E:F9:82:82:6A:76:FE:99:E0:EC:AD:68:0C:10:32:B1:4E:06:B3:00:A0:96:45:4C:0E:C2:FF:5F:04:44:88:47"
+            "7E:F9:82:82:6A:76:FE:99:E0:EC:AD:68:0C:10:32:B1:4E:06:B3:00:A0:96:45:4C:0E:C2:FF:5F:04:44:88:47"
         ]
     }
 }]

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -4,7 +4,7 @@
         "namespace": "android_app",
         "package_name": "app.thelist.twa",
         "sha256_cert_fingerprints": [
-        "7E:F9:82:82:6A:76:FE:99:E0:EC:AD:68:0C:10:32:B1:4E:06:B3:00:A0:96:45:4C:0E:C2:FF:5F:04:44:88:47",
+        "7E:F9:82:82:6A:76:FE:99:E0:EC:AD:68:0C:10:32:B1:4E:06:B3:00:A0:96:45:4C:0E:C2:FF:5F:04:44:88:47"
         ]
     }
 }]

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -1,0 +1,10 @@
+[{
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+        "namespace": "android_app",
+        "package_name": "app.thelist.twa",
+        "sha256_cert_fingerprints": [
+        "7E:F9:82:82:6A:76:FE:99:E0:EC:AD:68:0C:10:32:B1:4E:06:B3:00:A0:96:45:4C:0E:C2:FF:5F:04:44:88:47",
+        ]
+    }
+}]


### PR DESCRIPTION
Assetlink file for linking pwa to google play store.

Needs to be in folder structure "url/.well-known/assetlinks.json"

The pwa cannot be published or tested on the google play store until this file has been uploaded.